### PR TITLE
radar --explain: spell out why each score is what it is

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ gitsense scan pytorch/pytorch --skills python --updated-days 14
 
 # Score repos before investing a weekend (Markdown or JSON evidence)
 gitsense radar vllm-project/vllm microsoft/qlib --skills python,llm --out radar.md
+gitsense radar vllm-project/vllm --explain  # spell out why each score is what it is
 gitsense radar --targets targets.txt --skills python,agents --format json --out radar.json
 
 # Predict whether a specific open PR will merge (0–100 from public signals)

--- a/README_CN.md
+++ b/README_CN.md
@@ -102,6 +102,7 @@ gitsense scan pytorch/pytorch --skills python --updated-days 14
 
 # 提 PR 前评估仓库（Markdown 或 JSON 证据）
 gitsense radar vllm-project/vllm microsoft/qlib --skills python,llm --out radar.md
+gitsense radar vllm-project/vllm --explain  # 逐条摊开每个分数背后的加减分理由
 gitsense radar --targets targets.txt --skills python,agents --format json --out radar.json
 
 # 预测某个 open PR 会不会被合（按公开信号打 0-100 分）

--- a/gitsense/cli.py
+++ b/gitsense/cli.py
@@ -282,6 +282,7 @@ def scan(repo: str, skills: str, updated_days: int, max_comments: int | None):
 @click.option("--sample", default=20, show_default=True, help="Merged PR sample size per repo")
 @click.option("--format", "fmt", type=click.Choice(["md", "json"]), default="md")
 @click.option("--out", type=click.Path(dir_okay=False), help="Write a report file")
+@click.option("--explain", is_flag=True, help="Show why each repo got its score, one signal per line")
 def radar(
     repos: tuple[str, ...],
     targets: str | None,
@@ -291,6 +292,7 @@ def radar(
     sample: int,
     fmt: str,
     out: str | None,
+    explain: bool,
 ):
     """Score repos before you spend a weekend on a PR.
 
@@ -334,7 +336,7 @@ def radar(
     if fmt == "json" and not out:
         console.print_json(json.dumps([asdict(report) for report in reports]))
     else:
-        _print_radar_results(reports)
+        _print_radar_results(reports, explain=explain)
 
     if out:
         from gitsense.radar import render_json
@@ -344,7 +346,7 @@ def radar(
         console.print(f"\n[green]Wrote report:[/green] {out}")
 
 
-def _print_radar_results(reports) -> None:
+def _print_radar_results(reports, explain: bool = False) -> None:
     t = Table(title="GitSense Radar", show_lines=False)
     t.add_column("Repo", style="bold", max_width=34)
     t.add_column("Score", justify="right", width=5)
@@ -371,6 +373,13 @@ def _print_radar_results(reports) -> None:
         )
 
     console.print(t)
+    if explain:
+        for report in reports:
+            console.print(f"\n[bold]{report.repo}[/bold] [dim]score {report.score}[/dim]")
+            for note in report.notes:
+                console.print(f"  [dim]•[/dim] {note}")
+            if report.risk_flags:
+                console.print(f"  [yellow]flags:[/yellow] {', '.join(report.risk_flags)}")
     console.print("\n[dim]Signals use public GitHub PR history. Treat this as a triage pass, not a guarantee.[/dim]")
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -207,3 +207,35 @@ def test_find_markdown_export_to_file(monkeypatch, tmp_path):
     text = out.read_text(encoding="utf-8")
     assert text.startswith("# GitSense results for: python")
     assert "[issue 1](https://github.com/o/r/issues/1)" in text
+
+
+def test_radar_explain_prints_score_reasons(monkeypatch):
+    from gitsense.radar import RepoRadarReport
+
+    report = RepoRadarReport(
+        repo="o/r",
+        score=83,
+        recommendation="worth a PR",
+        stars=1234,
+        primary_language="python",
+        merged_prs=42,
+        open_prs=7,
+        stale_prs=1,
+        stale_ratio=0.14,
+        median_merge_days=3.5,
+        median_maintainer_response_days=1.0,
+        external_merged_ratio=0.6,
+        open_to_merged_ratio=0.17,
+        skill_matches=["python"],
+        notes=["fast median merge time", "outside contributors are getting merged"],
+        risk_flags=[],
+    )
+    monkeypatch.setattr("gitsense.radar.analyze_repo", lambda *a, **k: report)
+
+    plain = CliRunner().invoke(main, ["radar", "o/r"])
+    assert "fast median merge time" not in plain.output
+
+    explained = CliRunner().invoke(main, ["radar", "o/r", "--explain"])
+    assert explained.exit_code == 0
+    assert "fast median merge time" in explained.output
+    assert "outside contributors are getting merged" in explained.output


### PR DESCRIPTION
First roadmap item from #5.

`score_repo` already records one note per scoring delta ("fast median merge time", "many stale open PRs", ...), but the terminal table only showed the bare number, so the reason chain never reached the user. `gitsense radar <repo> --explain` now prints the signals under each repo row; markdown/json exports already carried them; default output unchanged.

Tests: new CLI test covers both that the default table hides notes and that --explain surfaces them. 105 passed, ruff clean.